### PR TITLE
Make the list navigation buttons work

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -318,6 +318,13 @@ int main() {
         std::string id = event.custom_id;
 
         if (id.find("page_next_") == 0) {
+            poke::ListNextPage(event);
+            return;
+        }
+
+        if (id.find("page_prev_") == 0) {
+            poke::ListPrevPage(event);
+            return;
         }
     });
 

--- a/src/poke.cpp
+++ b/src/poke.cpp
@@ -1483,12 +1483,14 @@ namespace poke {
 
         constexpr int offset = 10; // strlen("page_next_") == 10
         int current_page = std::stoi(event.custom_id.substr(offset));
-        if (current_page >= (users[id].pokemon.size() / 15)) {
-            event.reply("You don't have that many pokemons. Consider getting more.");
-            return;
+        int next_page = current_page + 1;
+        if (current_page >= (users[id].pokemon.size() / 15))
+        {
+            // Roll over to the beginning
+            next_page = 0;
         }
 
-        event.reply(ListPage(current_page + 1, event.command.channel_id, id));
+        event.reply(ListPage(next_page, event.command.channel_id, id));
     }
 
     void ListPrevPage(const dpp::button_click_t& event)
@@ -1499,13 +1501,14 @@ namespace poke {
 
         constexpr int offset = 10; // strlen("page_prev_") == 10
         int current_page = std::stoi(event.custom_id.substr(offset));
+        int previous_page = current_page - 1;
         if (current_page == 0)
         {
-            event.reply("You are already at the beginning. Try to think about it better.");
-            return;
+            // Roll over to the end
+            previous_page = (users[id].pokemon.size() / 15);
         }
 
-        event.reply(ListPage(current_page - 1, event.command.channel_id, id));
+        event.reply(ListPage(previous_page, event.command.channel_id, id));
     }
 
     void Favorite(const dpp::slashcommand_t& event)

--- a/src/poke.cpp
+++ b/src/poke.cpp
@@ -1458,9 +1458,9 @@ namespace poke {
         dpp::message msg(channel_id, embed);
         msg.add_component(
             dpp::component().add_component(
-                dpp::component().set_emoji("⬅️").set_label("Previous").set_style(dpp::cos_primary).set_id("page_prev_" + std::to_string(page))
+                dpp::component().set_emoji("⬅️").set_label("Previous").set_style(dpp::cos_primary).set_id("page_prev_" + std::to_string(id) + "_" + std::to_string(page))
             ).add_component(
-                dpp::component().set_emoji("➡️").set_label("Next").set_style(dpp::cos_primary).set_id("page_next_" + std::to_string(page))
+                dpp::component().set_emoji("➡️").set_label("Next").set_style(dpp::cos_primary).set_id("page_next_" + std::to_string(id) + "_" + std::to_string(page))
             )
         );
         return msg;
@@ -1478,37 +1478,43 @@ namespace poke {
     void ListNextPage(const dpp::button_click_t& event)
     {
         std::lock_guard<std::mutex> lock(mtx);
-        uint64_t id = event.command.get_issuing_user().id;
-        CheckAndCreateUser(id);
 
         constexpr int offset = 10; // strlen("page_next_") == 10
-        int current_page = std::stoi(event.custom_id.substr(offset));
-        int next_page = current_page + 1;
-        if (current_page >= (users[id].pokemon.size() / 15))
-        {
-            // Roll over to the beginning
-            next_page = 0;
-        }
+        std::string button_data = event.custom_id.substr(offset);
+        int page_offset = button_data.find('_');
+        if (page_offset != std::string::npos) {
+            uint64_t id = std::stoull(button_data);
+            int current_page = std::stoi(button_data.substr(page_offset + 1)); // + 1 to skip the "_" character
+            int next_page = current_page + 1;
+            if (current_page >= (users[id].pokemon.size() / 15))
+            {
+                // Roll over to the beginning
+                next_page = 0;
+            }
 
-        event.reply(ListPage(next_page, event.command.channel_id, id));
+            event.reply(dpp::ir_update_message, ListPage(next_page, event.command.channel_id, id));
+        }
     }
 
     void ListPrevPage(const dpp::button_click_t& event)
     {
         std::lock_guard<std::mutex> lock(mtx);
-        uint64_t id = event.command.get_issuing_user().id;
-        CheckAndCreateUser(id);
 
         constexpr int offset = 10; // strlen("page_prev_") == 10
-        int current_page = std::stoi(event.custom_id.substr(offset));
-        int previous_page = current_page - 1;
-        if (current_page == 0)
-        {
-            // Roll over to the end
-            previous_page = (users[id].pokemon.size() / 15);
-        }
+        std::string button_data = event.custom_id.substr(offset);
+        int page_offset = button_data.find('_');
+        if (page_offset != std::string::npos) {
+            uint64_t id = std::stoull(button_data);
+            int current_page = std::stoi(button_data.substr(page_offset + 1)); // + 1 to skip the "_" character
+            int previous_page = current_page - 1;
+            if (current_page == 0)
+            {
+                // Roll over to the end
+                previous_page = (users[id].pokemon.size() / 15);
+            }
 
-        event.reply(ListPage(previous_page, event.command.channel_id, id));
+            event.reply(dpp::ir_update_message, ListPage(previous_page, event.command.channel_id, id));
+        }
     }
 
     void Favorite(const dpp::slashcommand_t& event)

--- a/src/poke.cpp
+++ b/src/poke.cpp
@@ -1438,7 +1438,7 @@ namespace poke {
         std::string description = "";
         for (int index = page * 15; index < page * 15 + 15; index++)
         {
-            if (index >= names.size())
+            if (index >= users[id].pokemon.size())
             {
                 break;
             }
@@ -1458,9 +1458,9 @@ namespace poke {
         dpp::message msg(channel_id, embed);
         msg.add_component(
             dpp::component().add_component(
-                dpp::component().set_emoji("⬅️").set_label("Previous").set_style(dpp::cos_primary).set_id("page_prev_0")
+                dpp::component().set_emoji("⬅️").set_label("Previous").set_style(dpp::cos_primary).set_id("page_prev_" + std::to_string(page))
             ).add_component(
-                dpp::component().set_emoji("➡️").set_label("Next").set_style(dpp::cos_primary).set_id("page_next_0")
+                dpp::component().set_emoji("➡️").set_label("Next").set_style(dpp::cos_primary).set_id("page_next_" + std::to_string(page))
             )
         );
         return msg;
@@ -1473,6 +1473,39 @@ namespace poke {
         CheckAndCreateUser(id);
 
         event.reply(ListPage(0, event.command.channel_id, id));
+    }
+
+    void ListNextPage(const dpp::button_click_t& event)
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        uint64_t id = event.command.get_issuing_user().id;
+        CheckAndCreateUser(id);
+
+        constexpr int offset = 10; // strlen("page_next_") == 10
+        int current_page = std::stoi(event.custom_id.substr(offset));
+        if (current_page >= (users[id].pokemon.size() / 15)) {
+            event.reply("You don't have that many pokemons. Consider getting more.");
+            return;
+        }
+
+        event.reply(ListPage(current_page + 1, event.command.channel_id, id));
+    }
+
+    void ListPrevPage(const dpp::button_click_t& event)
+    {
+        std::lock_guard<std::mutex> lock(mtx);
+        uint64_t id = event.command.get_issuing_user().id;
+        CheckAndCreateUser(id);
+
+        constexpr int offset = 10; // strlen("page_prev_") == 10
+        int current_page = std::stoi(event.custom_id.substr(offset));
+        if (current_page == 0)
+        {
+            event.reply("You are already at the beginning. Try to think about it better.");
+            return;
+        }
+
+        event.reply(ListPage(current_page - 1, event.command.channel_id, id));
     }
 
     void Favorite(const dpp::slashcommand_t& event)

--- a/src/poke.hpp
+++ b/src/poke.hpp
@@ -15,5 +15,7 @@ namespace poke {
     void Leaderboard(const dpp::slashcommand_t& event);
     void Roulette(const dpp::slashcommand_t& event);
     dpp::message ListPage(int page, uint64_t channel_id, uint64_t id);
+    void ListNextPage(const dpp::button_click_t& event);
+    void ListPrevPage(const dpp::button_click_t& event);
 
 }


### PR DESCRIPTION
When a user interacts with the Previous or Next button, it will show the next or previous page of the list, or rolls to the beginning or end if the user tries to go out of bounds.

Note that the bot will reply to the message with the buttons (in other words, its own message). It will also use the list of the user who is interacting with the buttons, not the user who originally triggered the list command. I'm not sure how to fix these issues though since I don't know if it's possible or how to get the ID of the user who initially triggered the list, which would allow solving these issues.

Example:

![image](https://github.com/user-attachments/assets/b98f40cc-4aa3-4911-9ea5-6afaa0b40416)
