### PR TITLE
Always show caller in the leaderboard

### DIFF
--- a/src/poke.cpp
+++ b/src/poke.cpp
@@ -1624,13 +1624,29 @@ namespace poke {
 
         std::string description = "";
         int i = 1;
+        bool selfLeaderboard = false;
 
         for (auto& user : leaderboard)
         {
-            description += std::to_string(i) + ". <@" + std::to_string(user.first) + "> - " + std::to_string(user.second) + " points\n";
+            if (id == user.first)
+            {
+                selfLeaderboard = true;
+            }
+
+            if (i <= 10 || id == user.first)
+            {
+                // Add extra spacing for the ranking of the caller if not in top 10
+                if (i > 10)
+                {
+                    description += "\n";
+                }
+
+                description += std::to_string(i) + ". <@" + std::to_string(user.first) + "> - " + std::to_string(user.second) + " points\n";
+            }
+
             i++;
 
-            if (i > 10)
+            if (i > 10 && selfLeaderboard)
             {
                 break;
             }


### PR DESCRIPTION
If the user viewing the leaderboard isn't in top 10, show the place where they are located, alongside their points. This allows users who aren't on the leaderboard to view their points and their position.

Image for reference:

![image](https://github.com/user-attachments/assets/8ebe7b6c-164f-46fa-8dfc-d92edca51323)
